### PR TITLE
Improvement to automatically resolve dependencies from gradle

### DIFF
--- a/src/main/groovy/org/walkmod/gradle/WalkmodPlugin.groovy
+++ b/src/main/groovy/org/walkmod/gradle/WalkmodPlugin.groovy
@@ -32,32 +32,28 @@ class WalkmodPlugin implements Plugin<Project> {
 
 	void apply(Project project) {
 		project.apply(plugin: 'base')
-
 		project.extensions.create(EXTENSION, WalkmodExtension, project)
 
 		Configuration config = project.configurations.maybeCreate(EXTENSION)
+		config.extendsFrom(project.getConfigurations().getByName("testCompile"))
 
 		project.afterEvaluate {
 			project.tasks.findAll {it instanceof WalkmodAbstractTask && !it.configuration}.each {
 				it.configuration = config
 			}
-
 		}
 
 		project.task('walkmodCheck', type: WalkmodCheckTask, group: WALKMOD_GROUP) {
 			description = 'Checks which classes needs to be modified according your code transformations'
-			configuration = config
-		}
+		}.dependsOn "test"
 
 		project.task('walkmodApply', type: WalkmodApplyTask, group: WALKMOD_GROUP) {
 			description = 'Upgrades code to apply all code transformations'
-			configuration = config
-		}
+		}.dependsOn "test"
 
 		project.task('walkmodPatch', type: WalkmodPatchTask, group: WALKMOD_GROUP) {
 			description = 'Generates a patch according your code transformations'
-			configuration = config
-		}
+		}.dependsOn "test"
 
 		// Add configuration for plugins classpath
 		project.configurations {

--- a/src/test/groovy/org/walkmod/gradle/WalkmodAbstractTaskSpec.groovy
+++ b/src/test/groovy/org/walkmod/gradle/WalkmodAbstractTaskSpec.groovy
@@ -47,7 +47,6 @@ class WalkmodAbstractTaskSpec extends Specification {
 			!extension.offline
 			extension.verbose
 			extension.printErrors
-			extension.configFile == new File("walkmod.xml")
 	}
 	
 	def 'Tasks default values'() {
@@ -58,10 +57,9 @@ class WalkmodAbstractTaskSpec extends Specification {
 			WalkmodAbstractTask task = project.tasks.findByName(CHECK_TASK)
 			task != null
 			task.@chains  == null
-			task.@offline == null
-			task.@verbose == null
-			task.@printErrors == null
-			task.@configFile == null
+			task.@offline == false
+			task.@verbose == false
+			task.@printErrors == false
 	}
 	
 	def 'Task should overwrite extension values when null'() {
@@ -72,10 +70,9 @@ class WalkmodAbstractTaskSpec extends Specification {
 			WalkmodAbstractTask task = project.tasks.findByName(CHECK_TASK)
 			task != null
 			task.@chains  == null
-			task.@offline == null
-			task.@verbose == null
-			task.@printErrors == null
-			task.@configFile == null
+			task.@offline == false
+			task.@verbose == false
+			task.@printErrors == false
 
 		then: 'returned values are the ones of the the extension'
 			task != null
@@ -85,12 +82,10 @@ class WalkmodAbstractTaskSpec extends Specification {
 			!extension.offline
 			extension.verbose
 			extension.printErrors
-			extension.configFile == new File("walkmod.xml")
 			// values comparision
 			task.chains  == extension.chains
 			task.offline == extension.offline
 			task.verbose == extension.verbose
 			task.showErrors == extension.printErrors
-			task.configFile == extension.configFile
 	}
 }

--- a/src/test/groovy/org/walkmod/gradle/WalkmodScriptsSpec.groovy
+++ b/src/test/groovy/org/walkmod/gradle/WalkmodScriptsSpec.groovy
@@ -34,20 +34,28 @@ class WalkmodScriptsSpec extends Specification {
 	Project project
 
 	def setup() {
-		project = ProjectBuilder.builder().build()
+		project = ProjectBuilder.builder().withProjectDir(new File("src/test/resources/testProject")).build()
 	}
 
 	def "Applies script"() {
 		when:
+		    project.apply plugin: 'java'
 			project.apply plugin: WalkmodPlugin
+		    project.repositories {
+			   mavenCentral()
+		    }
+		    project.dependencies.add("compile", 'org.walkmod:walkmod-cmd:3.0.0')
 
 		then:
 			project[EXTENSION] != null
-	
+
 			// validate check task
-			Task checkTask = project.tasks.findByName('walkmodCheck')
+		    WalkmodCheckTask checkTask = project.tasks.findByName('walkmodCheck')
 			checkTask != null
 			checkTask.group == WALKMOD_GROUP
+		    checkTask.execute()
+		    URLClassLoader loader = checkTask.dynamicParams.get("classLoader")
+		    loader.URLs.size() > 1
 	
 			// validate check task
 			Task applyTask = project.tasks.findByName('walkmodApply')

--- a/src/test/resources/testProject/src/main/java/Foo.java
+++ b/src/test/resources/testProject/src/main/java/Foo.java
@@ -1,0 +1,3 @@
+public class Foo {
+
+}


### PR DESCRIPTION
This patch automatically sets the classLoader value with all the
gradle dependencies instead of delegating that step to walkmod.